### PR TITLE
Removes clown car from the uplink

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1534,7 +1534,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 1
 	restricted_roles = list("Clown")
 
-
+/**
 /datum/uplink_item/role_restricted/clowncar
 	name = "Clown Car"
 	desc = "The Clown Car is the ultimate transportation method for any worthy clown! \
@@ -1546,7 +1546,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/vehicle/sealed/car/clowncar
 	cost = 15
 	restricted_roles = list("Clown")
-
+**/
 
 // Pointless
 /datum/uplink_item/badass


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Comments out the clown car item from the uplink entirely, making it only able to be spawned by admins or the christmas tree.

## Why It's Good For The Game

Xyel has already expressed it being an LRP item, but the main thing about the clown car is that it's an incredibly overpowered gay baby jail you can't escape from unless you're REALLY lucky, and getting hit by it even once is game over. Sounds like a good idea on paper gameplay wise, fails in many regards due to poor balance. It's one of those things you should only be bringing out for events more than anything.

## Changelog
:cl:

tweak: Hid clown car from the uplink menus
balance: no more clown car
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
