### PR TITLE
Give the Light Replacer to Engineering Borgs.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -330,6 +330,13 @@
 	moduleselect_icon = "engineer"
 	magpulsing = TRUE
 	hat_offset = -4
+	
+/obj/item/robot_module/engineering/respawn_consumable(mob/living/silicon/robot/R, coeff = 1)
+	..()
+	var/obj/item/lightreplacer/LR = locate(/obj/item/lightreplacer) in basic_modules
+	if(LR)
+		for(var/i in 1 to coeff)
+			LR.Charge(R)
 
 /obj/item/robot_module/security
 	name = "Security"

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -309,6 +309,7 @@
 		/obj/item/crowbar/cyborg,
 		/obj/item/wirecutters/cyborg,
 		/obj/item/multitool/cyborg,
+		/obj/item/lightreplacer/cyborg,
 		/obj/item/t_scanner,
 		/obj/item/analyzer,
 		/obj/item/geiger_counter/cyborg,


### PR DESCRIPTION
## About The Pull Request

Adds the Light Replacer to the Engineering module on borgs. It also has the ability to charge in the charging stations, in the same way that Janitor borgs work with their Light Replacer. 

## Why It's Good For The Game

Found it ridiculous that engineering borgs could never replace lights in a room that was destroyed. Engineering module is almost a required round start borg to get everything ready and repair anything wrong.

## Changelog
:cl:
Add: Light Replacer to Engineering Module on Borgs.
/:cl:
